### PR TITLE
Support escaped characters in pgpass compatible with libpq

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,10 +1,10 @@
 (def project 'com.grzm/pique.alpha)
 (def version "0.1.6")
 
-(set-env! :resource-paths #{"resources" "src" "test/resources"}
-          :source-paths   #{"test/src"}
+(set-env! :resource-paths #{"test/resources"}
+          :source-paths   #{"src" "test/src"}
           :dependencies   '[[adzerk/boot-test "RELEASE" :scope "test"]
-                            [com.grzm/tespresso.alpha "0.1.3"]
+                            [com.grzm/tespresso.alpha "0.1.11"]
                             [metosin/boot-alt-test "0.3.2" :scope "test"]
                             [org.clojure/clojure "RELEASE"]
                             [org.clojure/spec.alpha "0.1.123" :scope "test"]

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,3 @@
+{:deps
+ {com.grzm/tespresso.alpha {:mvn/version "0.1.11"}
+  org.clojure/tools.logging {:mvn/version "0.4.0"}}}

--- a/src/com/grzm/pique/alpha/env/password.clj
+++ b/src/com/grzm/pique/alpha/env/password.clj
@@ -4,10 +4,12 @@
 
 (def field-separator #"(?<!\\):")
 
+(defn unescape [s] (str/replace s #"\\(.?)" "$1"))
+
 (defn parse-line
   [line]
-  (let [[host port dbname user password :as entry] (str/split line
-                                                              field-separator)]
+  (let [[host port dbname user password :as entry] (map unescape (str/split line
+                                                                            field-separator))]
     (when-not (<= 4 (count entry) 5)
       (throw (ex-info "invalid line" {:line line, :cause ::invalid-line})))
     {:host host, :port port, :dbname dbname, :user user, :password password}))

--- a/src/com/grzm/pique/alpha/env/password.clj
+++ b/src/com/grzm/pique/alpha/env/password.clj
@@ -4,7 +4,7 @@
 
 (def field-separator #"(?<!\\):")
 
-(defn unescape [s] (str/replace s #"\\(.?)" "$1"))
+(defn unescape [s] (str/replace s #"\\(.)" "$1"))
 
 (defn parse-line
   [line]

--- a/test/src/com/grzm/pique/alpha/env/password_test.clj
+++ b/test/src/com/grzm/pique/alpha/env/password_test.clj
@@ -55,11 +55,13 @@
                                  "*:*:*:me:some-pass"
                                  "*:*:*:me:abc\\\\d"
                                  "localhost:5432:mydb:someone:abcd\\\\"
+                                 "localhost:5432:mydb:someone:abcd\\"
                                  "localhost:5432:mydb:someone:ab\\:cd"])]
     (is (= [{:host "localhost" :port "*" :dbname "*" :user "me" :password nil}
             {:host "some-host" :port "5432" :dbname "*" :user "some-user" :password nil}
             {:host "*" :port "*" :dbname "*" :user "me" :password "some-pass"}
             {:host "*" :port "*" :dbname "*" :user "me" :password "abc\\d"}
+            {:host "localhost" :port "5432" :dbname "mydb" :user "someone" :password "abcd\\"}
             {:host "localhost" :port "5432" :dbname "mydb" :user "someone" :password "abcd\\"}
             {:host "localhost" :port "5432" :dbname "mydb" :user "someone" :password "ab:cd"}]
            (password/parse-passwords contents)))))

--- a/test/src/com/grzm/pique/alpha/env/password_test.clj
+++ b/test/src/com/grzm/pique/alpha/env/password_test.clj
@@ -54,12 +54,14 @@
                                  "some-host:5432:*:some-user:"
                                  "*:*:*:me:some-pass"
                                  "*:*:*:me:abc\\\\d"
-                                 "localhost:5432:mydb:someone:abcd\\\\"])]
+                                 "localhost:5432:mydb:someone:abcd\\\\"
+                                 "localhost:5432:mydb:someone:ab\\:cd"])]
     (is (= [{:host "localhost" :port "*" :dbname "*" :user "me" :password nil}
             {:host "some-host" :port "5432" :dbname "*" :user "some-user" :password nil}
             {:host "*" :port "*" :dbname "*" :user "me" :password "some-pass"}
             {:host "*" :port "*" :dbname "*" :user "me" :password "abc\\d"}
-            {:host "localhost" :port "5432" :dbname "mydb" :user "someone" :password "abcd\\"}]
+            {:host "localhost" :port "5432" :dbname "mydb" :user "someone" :password "abcd\\"}
+            {:host "localhost" :port "5432" :dbname "mydb" :user "someone" :password "ab:cd"}]
            (password/parse-passwords contents)))))
 
 (deftest bad-line-throws

--- a/test/src/com/grzm/pique/alpha/env/password_test.clj
+++ b/test/src/com/grzm/pique/alpha/env/password_test.clj
@@ -52,10 +52,14 @@
 (deftest parses-passwords-test
   (let [contents (str/join "\n" ["localhost:*:*:me:"
                                  "some-host:5432:*:some-user:"
-                                 "*:*:*:me:some-pass"])]
+                                 "*:*:*:me:some-pass"
+                                 "*:*:*:me:abc\\\\d"
+                                 "localhost:5432:mydb:someone:abcd\\\\"])]
     (is (= [{:host "localhost" :port "*" :dbname "*" :user "me" :password nil}
             {:host "some-host" :port "5432" :dbname "*" :user "some-user" :password nil}
-            {:host "*" :port "*" :dbname "*" :user "me" :password "some-pass"}]
+            {:host "*" :port "*" :dbname "*" :user "me" :password "some-pass"}
+            {:host "*" :port "*" :dbname "*" :user "me" :password "abc\\d"}
+            {:host "localhost" :port "5432" :dbname "mydb" :user "someone" :password "abcd\\"}]
            (password/parse-passwords contents)))))
 
 (deftest bad-line-throws

--- a/test/src/com/grzm/pique/alpha/env/system_environment_test.clj
+++ b/test/src/com/grzm/pique/alpha/env/system_environment_test.clj
@@ -49,7 +49,7 @@
 
 (defn create-temp-password-file [contents perms]
   (let [file (File/createTempFile "pique.env.test-" ".pgpass"
-                                  (io/file (str (temp-dir))))]
+                                  nil)]
     (.deleteOnExit file)
     (spit file contents)
     (set-perms (.toPath file) perms)


### PR DESCRIPTION
The [documentation for libpq](https://www.postgresql.org/docs/current/static/libpq-pgpass.html) describes characters stored in a `pgpass` file which must be escaped.

> If an entry needs to contain : or \\, escape this character with \\.

However, this library does not currently unescape values read from `pgpass`. This pull request adds that unescaping along with a few tests added after reviewing the above document and libpq source.

Also addressed was a change to temp file creation in tests (broken in my environment) in order to run the full test suite. 

A simple `deps.edn` file was added to allow reference as a dependency directly from git (for the temporary bugfix fork) supported by the new [tools.deps.alpha](https://github.com/clojure/tools.deps.alpha) dependency mechanism. I did not attempt to update the boot configuration (due to lack of familiarity) to use the new `deps.edn` file and eliminate redundancy though this should be possible via [boot-tools-deps](https://github.com/seancorfield/boot-tools-deps).
